### PR TITLE
module path can be set at command line

### DIFF
--- a/src/Cauterize/GHC7/Generate.hs
+++ b/src/Cauterize/GHC7/Generate.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE QuasiQuotes #-}
+
 module Cauterize.GHC7.Generate
        ( caut2hs
        ) where
@@ -14,16 +16,16 @@ import qualified Cauterize.GHC7.Generate.GenStack as GenStack
 import qualified Cauterize.GHC7.Generate.GenCrucibleClient as GenCrucibleClient
 
 caut2hs :: CautGHC7Opts -> IO ()
-caut2hs (CautGHC7Opts { specFile = specPath, outputDirectory = outPath }) = createGuard outPath $ do
-  spec <- Spec.parseSpecificationFromFile specPath
+caut2hs (opts@CautGHC7Opts{..}) = createGuard outputDirectory $ do
+  spec <- Spec.parseSpecificationFromFile specFile
 
   case spec of
     Left es -> error $ show es
-    Right s' -> generateOutput s' outPath
+    Right s' -> generateOutput s' opts
 
-generateOutput :: Spec.Specification -> FilePath -> IO ()
-generateOutput spec out = do
-  GenStack.generateOutput spec out
-  GenCabal.generateOutput spec out
-  GenCrucibleClient.generateOutput spec out
-  GenTypes.generateOutput spec out
+generateOutput :: Spec.Specification -> CautGHC7Opts -> IO ()
+generateOutput spec opts = do
+  GenStack.generateOutput spec opts
+  GenCabal.generateOutput spec opts
+  GenCrucibleClient.generateOutput spec opts
+  GenTypes.generateOutput spec opts

--- a/src/Cauterize/GHC7/Generate/GenCabal.hs
+++ b/src/Cauterize/GHC7/Generate/GenCabal.hs
@@ -10,6 +10,8 @@ import Data.String.Interpolate.Util
 import System.FilePath.Posix
 import qualified Cauterize.Specification as Spec
 import qualified Data.Text as T
+import Data.Maybe (fromMaybe)
+import Data.List (intercalate)
 
 generateOutput :: Spec.Specification -> CautGHC7Opts -> IO ()
 generateOutput spec opts = do
@@ -19,11 +21,13 @@ generateOutput spec opts = do
   writeFile genPath genData
   where
     specName = T.unpack (Spec.specName spec)
-    hsName = nameToHsName (Spec.specName spec)
+    hsName = fromMaybe
+      (intercalate "." ["Cauterize", "Generated", nameToHsName (Spec.specName spec)])
+      (modulePath opts)
     out = outputDirectory opts
 
 genTempl :: String -> String -> String
-genTempl name libname = unindent [i|
+genTempl name modname = unindent [i|
   name:                #{name}
   version:             0.0.0.1
   build-type:          Simple
@@ -40,7 +44,7 @@ genTempl name libname = unindent [i|
   library
     hs-source-dirs:      src
     default-language:    Haskell2010
-    exposed-modules:     Cauterize.Generated.#{libname}.Types
+    exposed-modules:     #{modname}.Types
     build-depends:       base < 5,
                          caut-ghc7-ref,
                          cereal,

--- a/src/Cauterize/GHC7/Generate/GenCabal.hs
+++ b/src/Cauterize/GHC7/Generate/GenCabal.hs
@@ -4,14 +4,15 @@ module Cauterize.GHC7.Generate.GenCabal
        ) where
 
 import Cauterize.GHC7.Generate.Utils
+import Cauterize.GHC7.Options
 import Data.String.Interpolate.IsString
 import Data.String.Interpolate.Util
 import System.FilePath.Posix
 import qualified Cauterize.Specification as Spec
 import qualified Data.Text as T
 
-generateOutput :: Spec.Specification -> FilePath -> IO ()
-generateOutput spec out = do
+generateOutput :: Spec.Specification -> CautGHC7Opts -> IO ()
+generateOutput spec opts = do
   genDir <- createPath [out]
   let genPath = genDir `combine` (specName ++ ".cabal")
   let genData = genTempl specName hsName
@@ -19,6 +20,7 @@ generateOutput spec out = do
   where
     specName = T.unpack (Spec.specName spec)
     hsName = nameToHsName (Spec.specName spec)
+    out = outputDirectory opts
 
 genTempl :: String -> String -> String
 genTempl name libname = unindent [i|

--- a/src/Cauterize/GHC7/Generate/GenCrucibleClient.hs
+++ b/src/Cauterize/GHC7/Generate/GenCrucibleClient.hs
@@ -3,6 +3,7 @@ module Cauterize.GHC7.Generate.GenCrucibleClient
        ( generateOutput
        ) where
 
+import Cauterize.GHC7.Options
 import Cauterize.GHC7.Generate.Utils
 import Data.String.Interpolate.IsString
 import Data.String.Interpolate.Util
@@ -10,8 +11,8 @@ import System.FilePath.Posix
 import qualified Cauterize.Specification as Spec
 import qualified Data.Text as T
 
-generateOutput :: Spec.Specification -> FilePath -> IO ()
-generateOutput spec out = do
+generateOutput :: Spec.Specification -> CautGHC7Opts -> IO ()
+generateOutput spec opts = do
   genDir <- createPath [out, "crucible"]
   let genPath = genDir `combine` "Main.hs"
   let genData = genTempl hsName specName
@@ -19,6 +20,7 @@ generateOutput spec out = do
   where
     specName = T.unpack (Spec.specName spec)
     hsName = nameToHsName (Spec.specName spec)
+    out = outputDirectory opts
 
 genTempl :: String -> String -> String
 genTempl _ _ = unindent [i|

--- a/src/Cauterize/GHC7/Generate/GenStack.hs
+++ b/src/Cauterize/GHC7/Generate/GenStack.hs
@@ -3,18 +3,21 @@ module Cauterize.GHC7.Generate.GenStack
        ( generateOutput
        ) where
 
+import Cauterize.GHC7.Options
 import Cauterize.GHC7.Generate.Utils
 import qualified Cauterize.Specification as Spec
 import System.FilePath.Posix
 import Data.String.Interpolate.Util
 import Data.String.Interpolate.IsString
 
-generateOutput :: Spec.Specification -> FilePath -> IO ()
-generateOutput _ out = do
+generateOutput :: Spec.Specification -> CautGHC7Opts -> IO ()
+generateOutput _ opts = do
     stackDir <- createPath [out]
     let stackPath = stackDir `combine` "stack.yaml"
     let stackData = stackYamlTempl
     writeFile stackPath stackData
+  where
+    out = outputDirectory opts
 
 stackYamlTempl :: String
 stackYamlTempl = unindent [i|

--- a/src/Cauterize/GHC7/Generate/GenTypes.hs
+++ b/src/Cauterize/GHC7/Generate/GenTypes.hs
@@ -3,6 +3,7 @@ module Cauterize.GHC7.Generate.GenTypes
        ( generateOutput
        ) where
 
+import Cauterize.GHC7.Options
 import Cauterize.GHC7.Generate.Utils
 import Data.String.Interpolate.IsString
 import Data.String.Interpolate.Util
@@ -13,14 +14,15 @@ import qualified Cauterize.Hash as H
 import Data.List (intercalate)
 import Data.Maybe (catMaybes)
 
-generateOutput :: Spec.Specification -> FilePath -> IO ()
-generateOutput spec out = do
+generateOutput :: Spec.Specification -> CautGHC7Opts -> IO ()
+generateOutput spec opts = do
   genDir <- createPath [out, "src", "Cauterize", "Generated", hsName]
   let genPath = genDir `combine` "Types.hs"
   let genData = genTempl hsName spec
   writeFile genPath genData
   where
     hsName = nameToHsName (Spec.specName spec)
+    out = outputDirectory opts
 
 genTempl :: String -> Spec.Specification -> String
 genTempl libname spec = unlines parts

--- a/src/Cauterize/GHC7/Options.hs
+++ b/src/Cauterize/GHC7/Options.hs
@@ -1,5 +1,6 @@
 module Cauterize.GHC7.Options
   ( CautGHC7Opts(..)
+  , modulePathAsList
   ) where
 
 data CautGHC7Opts = CautGHC7Opts
@@ -7,3 +8,14 @@ data CautGHC7Opts = CautGHC7Opts
   , outputDirectory :: FilePath
   , modulePath :: Maybe String
   } deriving (Show)
+
+modulePathAsList :: CautGHC7Opts -> Maybe [String]
+modulePathAsList opts = splitWith (== '.') <$> modulePath opts
+  where
+  splitWith :: (a -> Bool) -> [a] -> [[a]]
+  splitWith _    [] = []
+  splitWith cond xs = first : splitWith cond (safeTail rest)
+      where (first, rest) = break cond xs
+  safeTail [] = []
+  safeTail (_:ys) = ys
+

--- a/src/Cauterize/GHC7/Options.hs
+++ b/src/Cauterize/GHC7/Options.hs
@@ -5,4 +5,5 @@ module Cauterize.GHC7.Options
 data CautGHC7Opts = CautGHC7Opts
   { specFile :: FilePath
   , outputDirectory :: FilePath
+  , modulePath :: Maybe String
   } deriving (Show)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -25,6 +25,12 @@ optParser = CautGHC7Opts
    <> metavar "OUTPUT_PATH"
    <> help "Directory to save output files"
     )
+  <*> option (Just <$> str)
+    ( long "module-path"
+   <> metavar "Module.Path"
+   <> help "override default haskell module path"
+   <> value Nothing
+    )
 
 options :: ParserInfo CautGHC7Opts
 options = info (optParser <**> helper)

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
 - '.'
 - location:
     git: https://github.com/cauterize-tools/cauterize.git
-    commit: bcd3ffefc677a02c0bbf95e7e806d1bf0b33d6dd
+    commit: c4ea4a90
 - location:
     git: https://github.com/cauterize-tools/crucible.git
     commit: b2125cf19e64411c08b10a26bd8dffa17e11ec0e


### PR DESCRIPTION
Generated code can be given an arbitrary Haskell module path.
Instead of harcoding to `Cauterize.Generated.Foo.Types`, 
pass `—module-path Foo.Bar.Baz`, and that becomes `Foo.Bar.Baz.Types`