### PR TITLE
Build with cauterize 1.0.0

### DIFF
--- a/caut-ghc7-ref.cabal
+++ b/caut-ghc7-ref.cabal
@@ -21,7 +21,7 @@ executable caut-ghc7-ref
   build-depends:       base < 5,
                        optparse-applicative,
                        caut-ghc7-ref,
-                       cauterize <=0.1.0.0,
+                       cauterize,
                        bytestring,
                        directory,
                        text,
@@ -56,7 +56,7 @@ library
   default-language:    Haskell2010
   ghc-options:         -Wall -Werror
   build-depends:       base < 5,
-                       cauterize <=0.1.0.0,
+                       cauterize,
                        mtl,
                        transformers,
                        bytestring,

--- a/src/Cauterize/GHC7/Options.hs
+++ b/src/Cauterize/GHC7/Options.hs
@@ -26,26 +26,24 @@ optParser :: Parser CautGHC7Opts
 optParser = CautGHC7Opts
   <$> argument str
     ( metavar "SPEC"
-   <> help "Cauterize specification"
+   `mappend` help "Cauterize specification"
     )
   <*> argument str
     ( metavar "OUTDIR"
-   <> help "Output directory"
+   `mappend` help "Output directory"
     )
   <*> option (Just <$> str)
     ( long "module-path"
-   <> metavar "Module.Path"
-   <> help "override default haskell module path"
-   <> value Nothing
+   `mappend` metavar "Module.Path"
+   `mappend` help "override default haskell module path"
+   `mappend` value Nothing
     )
 
 options :: ParserInfo (Maybe CautGHC7Opts)
 options = info (helper <*> o)
    ( fullDesc
-  <> progDesc "Translate a Cauterize specification into a Haskell implementation"
+  `mappend` progDesc "Translate a Cauterize specification into a Haskell implementation"
    )
   where
-  o = flag' Nothing (long "version" <> hidden)
+  o = flag' Nothing (long "version" `mappend` hidden)
    <|> (Just <$> optParser)
-
-

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,12 +3,12 @@ packages:
 - '.'
 - location:
     git: https://github.com/cauterize-tools/cauterize.git
-    commit: 12cc1c3b434fab9d460ddcd26fb391bc62a29d59
+    commit: 7d44a8e2c027a93d7937b29aa9915a082919f6c5
 - location:
     git: https://github.com/cauterize-tools/crucible.git
     commit: b2125cf19e64411c08b10a26bd8dffa17e11ec0e
 extra-deps:
-  - cereal-plus-0.4.1
+  - cereal-plus-0.4.2
   - s-cargot-0.1.0.0
   - gitrev-1.2.0
-resolver: lts-3.16
+resolver: lts-7.18


### PR DESCRIPTION
Update to using the latest cauterize tags and address the issue with `<>` that comes up when trying to build with the latest stackage nightly with ghc 8.0.2.